### PR TITLE
implement getConnectionInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidbcloud/prisma-adapter",
-  "version": "5.7.0",
+  "version": "5.8.0-dev.15",
   "description": "Prisma's driver adapter for \"@tidbcloud/serverless\"",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -32,16 +32,16 @@
   "license": "Apache-2.0",
   "sideEffects": false,
   "dependencies": {
-    "@prisma/driver-adapter-utils": "5.7.0"
+    "@prisma/driver-adapter-utils": "5.8.0-dev.15"
   },
   "devDependencies": {
-    "@tidbcloud/serverless": "^0.0.7",
+    "@tidbcloud/serverless": "^0.0.9",
     "@types/node": "^20.5.1",
     "tsup": "^7.2.0",
     "tsx": "^3.12.7",
     "typescript": "^5.1.6"
   },
   "peerDependencies": {
-    "@tidbcloud/serverless": "^0.0.7"
+    "@tidbcloud/serverless": "^0.0.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,13 +6,13 @@ settings:
 
 dependencies:
   '@prisma/driver-adapter-utils':
-    specifier: 5.7.0
-    version: 5.7.0
+    specifier: 5.8.0-dev.15
+    version: 5.8.0-dev.15
 
 devDependencies:
   '@tidbcloud/serverless':
-    specifier: ^0.0.7
-    version: 0.0.7
+    specifier: ^0.0.9
+    version: 0.0.9
   '@types/node':
     specifier: ^20.5.1
     version: 20.5.1
@@ -298,16 +298,16 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@prisma/driver-adapter-utils@5.7.0:
-    resolution: {integrity: sha512-GNVOIRS5SEVRfvgoYmWKMtKc7FOm0LYFiDUQYjfcc/FJAiY1XpzRPLPs8q/qW7RaQ7IDKYdOKngepWCRfH0sTw==}
+  /@prisma/driver-adapter-utils@5.8.0-dev.15:
+    resolution: {integrity: sha512-H4+QctoR4fbcPrkgwNxCTztzqLm0teWSQ9zMgxUSOizdckfmIakpSNJK7mXZTXPYJWtbyzZS8fr1VVrMBqC7bA==}
     dependencies:
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@tidbcloud/serverless@0.0.7:
-    resolution: {integrity: sha512-rj5l1j8voLcyeiXVA8UwKPfY8xQj8f740YOZHSasneIeiTYcFwLkBwAlzJDsEjgn20lJYf03E8sVCSf10FHulw==}
+  /@tidbcloud/serverless@0.0.9:
+    resolution: {integrity: sha512-kymM6nkBLQxUNUN75ESISjsFERd6Bd3L/Uxa1WeMNWpRnlVKcGGCGS6c//wedZvAYgciJaunvBzKL3/drHn8/Q==}
     engines: {node: '>=16'}
     dev: true
 

--- a/src/tidbcloud.ts
+++ b/src/tidbcloud.ts
@@ -1,6 +1,7 @@
 import type TiDBCloud from '@tidbcloud/serverless'
 import { Debug, ok } from '@prisma/driver-adapter-utils'
 import type {
+  ConnectionInfo,
   DriverAdapter,
   ResultSet,
   Query,
@@ -12,6 +13,8 @@ import type {
 import {type TiDBCloudColumnType,fieldToColumnType} from './conversion'
 
 const debug = Debug('prisma:driver-adapter:tidbcloud')
+
+const defaultDatabase = 'test'
 
 class RollbackError extends Error {
   constructor() {
@@ -122,6 +125,14 @@ class TiDBCloudTransaction extends TiDBCloudQueryable<TiDBCloud.Tx> implements T
 export class PrismaTiDBCloud extends TiDBCloudQueryable<TiDBCloud.Connection> implements DriverAdapter {
   constructor(client: TiDBCloud.Connection) {
     super(client)
+  }
+
+  getConnectionInfo(): Result<ConnectionInfo> {
+    const config = this.client.getConfig()
+    const dbName = config.database? config.database : defaultDatabase
+    return ok({
+      schemaName: dbName,
+    })
   }
 
   async startTransaction() {


### PR DESCRIPTION
The driver adapter must provide schema since the client will no longer use the connection string from schema. Now, only provides database can make things work

related to https://github.com/prisma/prisma-engines/pull/4548