### PR TITLE
Fix conversion for blob, binary and bit type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,5 @@ jobs:
         run: pnpm lint
       - name: build
         run: pnpm build
+      - name: fmt
+        run: pnpm fmt-check

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@shiyuhang0/prisma-adapter",
-  "version": "5.10.2-dev1",
+  "name": "@tidbcloud/prisma-adapter",
+  "version": "5.10.2",
   "description": "Prisma's driver adapter for \"@tidbcloud/serverless\"",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@tidbcloud/prisma-adapter",
-  "version": "5.9.1",
+  "name": "@shiyuhang0/prisma-adapter",
+  "version": "5.10.2-dev1",
   "description": "Prisma's driver adapter for \"@tidbcloud/serverless\"",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -32,16 +32,16 @@
   "license": "Apache-2.0",
   "sideEffects": false,
   "dependencies": {
-    "@prisma/driver-adapter-utils": "5.9.1"
+    "@prisma/driver-adapter-utils": "5.10.2"
   },
   "devDependencies": {
-    "@tidbcloud/serverless": "^0.0.10",
+    "@tidbcloud/serverless": "^0.1.0",
     "@types/node": "^20.5.1",
     "tsup": "^7.2.0",
     "tsx": "^3.12.7",
     "typescript": "^5.1.6"
   },
   "peerDependencies": {
-    "@tidbcloud/serverless": ">= 0.0.10"
+    "@tidbcloud/serverless": ">= 0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsup ./src/index.ts --format cjs,esm --dts",
-    "lint": "tsc -p ./tsconfig.build.json"
+    "lint": "tsc -p ./tsconfig.build.json",
+    "fmt": "prettier --write ./src",
+    "fmt-check": "prettier --check ./src"
   },
   "files": [
     "dist",
@@ -39,7 +41,8 @@
     "@types/node": "^20.5.1",
     "tsup": "^7.2.0",
     "tsx": "^3.12.7",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "prettier": "^2.7.1"
   },
   "peerDependencies": {
     "@tidbcloud/serverless": ">= 0.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,13 +6,13 @@ settings:
 
 dependencies:
   '@prisma/driver-adapter-utils':
-    specifier: 5.9.1
-    version: 5.9.1
+    specifier: 5.10.2
+    version: 5.10.2
 
 devDependencies:
   '@tidbcloud/serverless':
-    specifier: ^0.0.10
-    version: 0.0.10
+    specifier: ^0.1.0
+    version: 0.1.0
   '@types/node':
     specifier: ^20.5.1
     version: 20.5.1
@@ -298,16 +298,18 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@prisma/driver-adapter-utils@5.9.1:
-    resolution: {integrity: sha512-1h1+6kU3PfsE2CvQoU49Jt7yrXybU0C/H/+W8Bh0pJefMAbTY8KoWssYXgwQp1PUKBtdh1GDQsMf9ojFeQ0RWg==}
-    dependencies:
-      debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
+  /@prisma/debug@5.10.2:
+    resolution: {integrity: sha512-bkBOmH9dpEBbMKFJj8V+Zp8IZHIBjy3fSyhLhxj4FmKGb/UBSt9doyfA6k1UeUREsMJft7xgPYBbHSOYBr8XCA==}
     dev: false
 
-  /@tidbcloud/serverless@0.0.10:
-    resolution: {integrity: sha512-DmT6dT6VjeCvVmNlBwRPdQK95ZMI/m5z8lOklpS5qZAt8bntx68dihd14faw8JYke4ZQz/vbfoM5svQt7MPoOg==}
+  /@prisma/driver-adapter-utils@5.10.2:
+    resolution: {integrity: sha512-Qou/js8VJSmaWiGX5EVXGF83fMZltFnuzkKFOocpDvcI3f5G9WTPf61TKflzs3ZOYe1weRgM9hUk9UR7lgGEwg==}
+    dependencies:
+      '@prisma/debug': 5.10.2
+    dev: false
+
+  /@tidbcloud/serverless@0.1.0:
+    resolution: {integrity: sha512-Zw68iV/7ICMgPOsdpFa3QdHWzbfLG6ZMKb5Qe1DpFjT5fFk2HgYAm7XfuxxOPxKDhwY1Ou+7bqfuntOnd1fasg==}
     engines: {node: '>=16'}
     dev: true
 
@@ -417,6 +419,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+    dev: true
 
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -654,6 +657,7 @@ packages:
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    dev: true
 
   /mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ devDependencies:
   '@types/node':
     specifier: ^20.5.1
     version: 20.5.1
+  prettier:
+    specifier: ^2.7.1
+    version: 2.7.1
   tsup:
     specifier: ^7.2.0
     version: 7.2.0(typescript@5.1.6)
@@ -736,6 +739,12 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       yaml: 2.3.2
+    dev: true
+
+  /prettier@2.7.1:
+    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
     dev: true
 
   /punycode@2.3.0:

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -94,7 +94,7 @@ export function fieldToColumnType(field: TiDBCloudColumnType): ColumnType {
 }
 
 // define the decoder because TiDB Cloud serverless driver returns Uint8Array for these type
-export const customerDecoder = {
+export const customDecoder = {
   "BINARY": (value: string) => Array.from(hexToUint8Array(value)),
   "VARBINARY": (value: string) => Array.from(hexToUint8Array(value)),
   "BLOB": (value: string) => Array.from(hexToUint8Array(value)),

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -95,13 +95,13 @@ export function fieldToColumnType(field: TiDBCloudColumnType): ColumnType {
 
 // define the decoder because TiDB Cloud serverless driver returns Uint8Array for these type
 export const customerDecoder = {
-  ["BINARY"]: (value: string) => Array.from(hexToUint8Array(value)),
-  ["VARBINARY"]: (value: string) => Array.from(hexToUint8Array(value)),
-  ["BLOB"]: (value: string) => Array.from(hexToUint8Array(value)),
-  ["LONGBLOB"]: (value: string) => Array.from(hexToUint8Array(value)),
-  ["TINYINT"]: (value: string) => Array.from(hexToUint8Array(value)),
-  ["MEDIUMBLOB"]: (value: string) => Array.from(hexToUint8Array(value)),
-  ["BIT"]: (value: string) => Array.from(hexToUint8Array(value)),
+  "BINARY": (value: string) => Array.from(hexToUint8Array(value)),
+  "VARBINARY": (value: string) => Array.from(hexToUint8Array(value)),
+  "BLOB": (value: string) => Array.from(hexToUint8Array(value)),
+  "LONGBLOB": (value: string) => Array.from(hexToUint8Array(value)),
+  "TINYINT": (value: string) => Array.from(hexToUint8Array(value)),
+  "MEDIUMBLOB": (value: string) => Array.from(hexToUint8Array(value)),
+  "BIT": (value: string) => Array.from(hexToUint8Array(value)),
 }
 
 function hexToUint8Array(hexString: string): Uint8Array {

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -1,39 +1,39 @@
-import { ColumnTypeEnum, type ColumnType } from '@prisma/driver-adapter-utils'
+import { ColumnTypeEnum, type ColumnType } from "@prisma/driver-adapter-utils";
 
-export type TiDBCloudColumnType
-    = 'NULL'
-    | 'TINYINT'
-    | 'UNSIGNED TINYINT'
-    | 'SMALLINT'
-    | 'UNSIGNED SMALLINT'
-    | 'MEDIUMINT'
-    | 'UNSIGNED MEDIUMINT'
-    | 'INT'
-    | 'UNSIGNED INT'
-    | 'YEAR'
-    | 'FLOAT'
-    | 'DOUBLE'
-    | 'BIGINT'
-    | 'UNSIGNED BIGINT'
-    | 'DECIMAL'
-    | 'CHAR'
-    | 'VARCHAR'
-    | 'BINARY'
-    | 'VARBINARY'
-    | 'TINYTEXT'
-    | 'TEXT'
-    | 'MEDIUMTEXT'
-    | 'LONGTEXT'
-    | 'TINYBLOB'
-    | 'BLOB'
-    | 'MEDIUMBLOB'
-    | 'LONGBLOB'
-    | 'DATE'
-    | 'TIME'
-    | 'DATETIME'
-    | 'TIMESTAMP'
-    | 'JSON'
-    | 'BIT'
+export type TiDBCloudColumnType =
+  | "NULL"
+  | "TINYINT"
+  | "UNSIGNED TINYINT"
+  | "SMALLINT"
+  | "UNSIGNED SMALLINT"
+  | "MEDIUMINT"
+  | "UNSIGNED MEDIUMINT"
+  | "INT"
+  | "UNSIGNED INT"
+  | "YEAR"
+  | "FLOAT"
+  | "DOUBLE"
+  | "BIGINT"
+  | "UNSIGNED BIGINT"
+  | "DECIMAL"
+  | "CHAR"
+  | "VARCHAR"
+  | "BINARY"
+  | "VARBINARY"
+  | "TINYTEXT"
+  | "TEXT"
+  | "MEDIUMTEXT"
+  | "LONGTEXT"
+  | "TINYBLOB"
+  | "BLOB"
+  | "MEDIUMBLOB"
+  | "LONGBLOB"
+  | "DATE"
+  | "TIME"
+  | "DATETIME"
+  | "TIMESTAMP"
+  | "JSON"
+  | "BIT";
 
 /**
  * This is a simplification of quaint's value inference logic. Take a look at quaint's conversion.rs
@@ -42,72 +42,72 @@ export type TiDBCloudColumnType
  */
 export function fieldToColumnType(field: TiDBCloudColumnType): ColumnType {
   switch (field) {
-    case 'TINYINT':
-    case 'UNSIGNED TINYINT':
-    case 'SMALLINT':
-    case 'UNSIGNED SMALLINT':
-    case 'MEDIUMINT':
-    case 'UNSIGNED MEDIUMINT':
-    case 'INT':
-    case 'YEAR':
-      return ColumnTypeEnum.Int32
-    case 'UNSIGNED INT':
-    case 'BIGINT':
-    case 'UNSIGNED BIGINT':
-      return ColumnTypeEnum.Int64
-    case 'FLOAT':
-      return ColumnTypeEnum.Float
-    case 'DOUBLE':
-      return ColumnTypeEnum.Double
-    case 'TIMESTAMP':
-    case 'DATETIME':
-      return ColumnTypeEnum.DateTime
-    case 'DATE':
-      return ColumnTypeEnum.Date
-    case 'TIME':
-      return ColumnTypeEnum.Time
-    case 'DECIMAL':
-      return ColumnTypeEnum.Numeric
-    case 'CHAR':
-    case 'TINYTEXT':
-    case 'TEXT':
-    case 'MEDIUMTEXT':
-    case 'LONGTEXT':
-    case 'VARCHAR':
-      return ColumnTypeEnum.Text
-    case 'JSON':
-      return ColumnTypeEnum.Json
-    case 'TINYBLOB':
-    case 'BLOB':
-    case 'MEDIUMBLOB':
-    case 'LONGBLOB':
-    case 'BINARY':
-    case 'VARBINARY':
-    case 'BIT':
-      return ColumnTypeEnum.Bytes
-    case 'NULL':
+    case "TINYINT":
+    case "UNSIGNED TINYINT":
+    case "SMALLINT":
+    case "UNSIGNED SMALLINT":
+    case "MEDIUMINT":
+    case "UNSIGNED MEDIUMINT":
+    case "INT":
+    case "YEAR":
+      return ColumnTypeEnum.Int32;
+    case "UNSIGNED INT":
+    case "BIGINT":
+    case "UNSIGNED BIGINT":
+      return ColumnTypeEnum.Int64;
+    case "FLOAT":
+      return ColumnTypeEnum.Float;
+    case "DOUBLE":
+      return ColumnTypeEnum.Double;
+    case "TIMESTAMP":
+    case "DATETIME":
+      return ColumnTypeEnum.DateTime;
+    case "DATE":
+      return ColumnTypeEnum.Date;
+    case "TIME":
+      return ColumnTypeEnum.Time;
+    case "DECIMAL":
+      return ColumnTypeEnum.Numeric;
+    case "CHAR":
+    case "TINYTEXT":
+    case "TEXT":
+    case "MEDIUMTEXT":
+    case "LONGTEXT":
+    case "VARCHAR":
+      return ColumnTypeEnum.Text;
+    case "JSON":
+      return ColumnTypeEnum.Json;
+    case "TINYBLOB":
+    case "BLOB":
+    case "MEDIUMBLOB":
+    case "LONGBLOB":
+    case "BINARY":
+    case "VARBINARY":
+    case "BIT":
+      return ColumnTypeEnum.Bytes;
+    case "NULL":
       // Fall back to Int32 for consistency with quaint.
-      return ColumnTypeEnum.Int32
+      return ColumnTypeEnum.Int32;
     default:
-      throw new Error(`Unsupported column type: ${field}`)
+      throw new Error(`Unsupported column type: ${field}`);
   }
 }
 
 // define the decoder because TiDB Cloud serverless driver returns Uint8Array for these type
 export const customDecoder = {
-  "BINARY": (value: string) => Array.from(hexToUint8Array(value)),
-  "VARBINARY": (value: string) => Array.from(hexToUint8Array(value)),
-  "BLOB": (value: string) => Array.from(hexToUint8Array(value)),
-  "LONGBLOB": (value: string) => Array.from(hexToUint8Array(value)),
-  "TINYINT": (value: string) => Array.from(hexToUint8Array(value)),
-  "MEDIUMBLOB": (value: string) => Array.from(hexToUint8Array(value)),
-  "BIT": (value: string) => Array.from(hexToUint8Array(value)),
-}
+  BINARY: (value: string) => Array.from(hexToUint8Array(value)),
+  VARBINARY: (value: string) => Array.from(hexToUint8Array(value)),
+  BLOB: (value: string) => Array.from(hexToUint8Array(value)),
+  LONGBLOB: (value: string) => Array.from(hexToUint8Array(value)),
+  TINYINT: (value: string) => Array.from(hexToUint8Array(value)),
+  MEDIUMBLOB: (value: string) => Array.from(hexToUint8Array(value)),
+  BIT: (value: string) => Array.from(hexToUint8Array(value)),
+};
 
 function hexToUint8Array(hexString: string): Uint8Array {
-  const uint8Array = new Uint8Array(hexString.length / 2)
+  const uint8Array = new Uint8Array(hexString.length / 2);
   for (let i = 0; i < hexString.length; i += 2) {
-    uint8Array[i / 2] = parseInt(hexString.substring(i, i + 2), 16)
+    uint8Array[i / 2] = parseInt(hexString.substring(i, i + 2), 16);
   }
-  return uint8Array
+  return uint8Array;
 }

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -92,3 +92,22 @@ export function fieldToColumnType(field: TiDBCloudColumnType): ColumnType {
       throw new Error(`Unsupported column type: ${field}`)
   }
 }
+
+// define the decoder because TiDB Cloud serverless driver returns Uint8Array for these type
+export const customerDecoder = {
+  ["BINARY"]: (value: string) => Array.from(hexToUint8Array(value)),
+  ["VARBINARY"]: (value: string) => Array.from(hexToUint8Array(value)),
+  ["BLOB"]: (value: string) => Array.from(hexToUint8Array(value)),
+  ["LONGBLOB"]: (value: string) => Array.from(hexToUint8Array(value)),
+  ["TINYINT"]: (value: string) => Array.from(hexToUint8Array(value)),
+  ["MEDIUMBLOB"]: (value: string) => Array.from(hexToUint8Array(value)),
+  ["BIT"]: (value: string) => Array.from(hexToUint8Array(value)),
+}
+
+function hexToUint8Array(hexString: string): Uint8Array {
+  const uint8Array = new Uint8Array(hexString.length / 2)
+  for (let i = 0; i < hexString.length; i += 2) {
+    uint8Array[i / 2] = parseInt(hexString.substring(i, i + 2), 16)
+  }
+  return uint8Array
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { PrismaTiDBCloud } from './tidbcloud'
+export { PrismaTiDBCloud } from "./tidbcloud";

--- a/src/tidbcloud.ts
+++ b/src/tidbcloud.ts
@@ -10,7 +10,7 @@ import type {
   Result,
   TransactionOptions,
 } from '@prisma/driver-adapter-utils'
-import {type TiDBCloudColumnType,fieldToColumnType,customerDecoder} from './conversion'
+import {type TiDBCloudColumnType,fieldToColumnType,customDecoder} from './conversion'
 
 const debug = Debug('prisma:driver-adapter:tidbcloud')
 
@@ -78,7 +78,7 @@ class TiDBCloudQueryable<ClientT extends TiDBCloud.Connection | TiDBCloud.Tx> im
     const { sql, args: values } = query
 
     try {
-      const result =  await this.client.execute(sql, values, {arrayMode: true, fullResult: true,decoders:customerDecoder})
+      const result =  await this.client.execute(sql, values, {arrayMode: true, fullResult: true, decoders:customDecoder})
       return result as TiDBCloud.FullResult
     } catch (e) {
       const error = e as Error

--- a/src/tidbcloud.ts
+++ b/src/tidbcloud.ts
@@ -1,5 +1,5 @@
-import type TiDBCloud from '@tidbcloud/serverless'
-import { Debug, ok } from '@prisma/driver-adapter-utils'
+import type TiDBCloud from "@tidbcloud/serverless";
+import { Debug, ok } from "@prisma/driver-adapter-utils";
 import type {
   ConnectionInfo,
   DriverAdapter,
@@ -9,50 +9,58 @@ import type {
   Transaction,
   Result,
   TransactionOptions,
-} from '@prisma/driver-adapter-utils'
-import {type TiDBCloudColumnType,fieldToColumnType,customDecoder} from './conversion'
+} from "@prisma/driver-adapter-utils";
+import {
+  type TiDBCloudColumnType,
+  fieldToColumnType,
+  customDecoder,
+} from "./conversion";
 
-const debug = Debug('prisma:driver-adapter:tidbcloud')
+const debug = Debug("prisma:driver-adapter:tidbcloud");
 
-const defaultDatabase = 'test'
+const defaultDatabase = "test";
 
 class RollbackError extends Error {
   constructor() {
-    super('ROLLBACK')
-    this.name = 'RollbackError'
+    super("ROLLBACK");
+    this.name = "RollbackError";
 
     if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, RollbackError)
+      Error.captureStackTrace(this, RollbackError);
     }
   }
 }
 
-class TiDBCloudQueryable<ClientT extends TiDBCloud.Connection | TiDBCloud.Tx> implements Queryable {
-  readonly provider = 'mysql'
+class TiDBCloudQueryable<ClientT extends TiDBCloud.Connection | TiDBCloud.Tx>
+  implements Queryable
+{
+  readonly provider = "mysql";
   constructor(protected client: ClientT) {}
 
   /**
    * Execute a query given as SQL, interpolating the given parameters.
    */
   async queryRaw(query: Query): Promise<Result<ResultSet>> {
-    const tag = '[js::query_raw]'
-    debug(`${tag} %O`, query)
+    const tag = "[js::query_raw]";
+    debug(`${tag} %O`, query);
 
-    const result = await this.performIO(query)
-    const fields = result.types as TiDBCloud.Types
-    const rows = result.rows as TiDBCloud.Row[]
-    const lastInsertId = result.lastInsertId?.toString()
+    const result = await this.performIO(query);
+    const fields = result.types as TiDBCloud.Types;
+    const rows = result.rows as TiDBCloud.Row[];
+    const lastInsertId = result.lastInsertId?.toString();
 
-    const columnNames = Object.keys(fields) as string[]
-    const columnRawTypes =  Object.values(fields) as string[]
+    const columnNames = Object.keys(fields) as string[];
+    const columnRawTypes = Object.values(fields) as string[];
 
     const resultSet: ResultSet = {
       columnNames,
-      columnTypes: columnRawTypes.map((field) => fieldToColumnType(field as TiDBCloudColumnType)),
-      rows: rows as ResultSet['rows'],
-      lastInsertId
-    }
-    return ok(resultSet)
+      columnTypes: columnRawTypes.map((field) =>
+        fieldToColumnType(field as TiDBCloudColumnType)
+      ),
+      rows: rows as ResultSet["rows"],
+      lastInsertId,
+    };
+    return ok(resultSet);
   }
 
   /**
@@ -61,12 +69,12 @@ class TiDBCloudQueryable<ClientT extends TiDBCloud.Connection | TiDBCloud.Tx> im
    * Note: Queryable expects a u64, but napi.rs only supports u32.
    */
   async executeRaw(query: Query): Promise<Result<number>> {
-    const tag = '[js::execute_raw]'
-    debug(`${tag} %O`, query)
+    const tag = "[js::execute_raw]";
+    debug(`${tag} %O`, query);
 
-    const result = await this.performIO(query)
-    const rowsAffected = result.rowsAffected as number
-    return ok(rowsAffected)
+    const result = await this.performIO(query);
+    const rowsAffected = result.rowsAffected as number;
+    return ok(rowsAffected);
   }
 
   /**
@@ -75,75 +83,82 @@ class TiDBCloudQueryable<ClientT extends TiDBCloud.Connection | TiDBCloud.Tx> im
    * marked as unhealthy.
    */
   private async performIO(query: Query) {
-    const { sql, args: values } = query
+    const { sql, args: values } = query;
 
     try {
-      const result =  await this.client.execute(sql, values, {arrayMode: true, fullResult: true, decoders:customDecoder})
-      return result as TiDBCloud.FullResult
+      const result = await this.client.execute(sql, values, {
+        arrayMode: true,
+        fullResult: true,
+        decoders: customDecoder,
+      });
+      return result as TiDBCloud.FullResult;
     } catch (e) {
-      const error = e as Error
-      debug('Error in performIO: %O', error)
-      throw error
+      const error = e as Error;
+      debug("Error in performIO: %O", error);
+      throw error;
     }
   }
 }
 
-class TiDBCloudTransaction extends TiDBCloudQueryable<TiDBCloud.Tx> implements Transaction {
-  finished = false
+class TiDBCloudTransaction
+  extends TiDBCloudQueryable<TiDBCloud.Tx>
+  implements Transaction
+{
+  finished = false;
 
-  constructor(
-    tx: TiDBCloud.Tx,
-    readonly options: TransactionOptions,
-  ) {
-    super(tx)
+  constructor(tx: TiDBCloud.Tx, readonly options: TransactionOptions) {
+    super(tx);
   }
 
   async commit(): Promise<Result<void>> {
-    debug(`[js::commit]`)
+    debug(`[js::commit]`);
 
-    this.finished = true
-    await this.client.commit()
-    return Promise.resolve(ok(undefined))
+    this.finished = true;
+    await this.client.commit();
+    return Promise.resolve(ok(undefined));
   }
 
   async rollback(): Promise<Result<void>> {
-    debug(`[js::rollback]`)
+    debug(`[js::rollback]`);
 
-    this.finished = true
-    await this.client.rollback()
-    return Promise.resolve(ok(undefined))
+    this.finished = true;
+    await this.client.rollback();
+    return Promise.resolve(ok(undefined));
   }
 
   dispose(): Result<void> {
     if (!this.finished) {
-      this.rollback().catch(console.error)
+      this.rollback().catch(console.error);
     }
-    return ok(undefined)
+    return ok(undefined);
   }
 }
 
-export class PrismaTiDBCloud extends TiDBCloudQueryable<TiDBCloud.Connection> implements DriverAdapter {
+export class PrismaTiDBCloud
+  extends TiDBCloudQueryable<TiDBCloud.Connection>
+  implements DriverAdapter
+{
   constructor(client: TiDBCloud.Connection) {
-    super(client)
+    super(client);
   }
 
   getConnectionInfo(): Result<ConnectionInfo> {
-    const config = this.client.getConfig()
-    const dbName = config.database? config.database : defaultDatabase
+    const config = this.client.getConfig();
+    const dbName = config.database ? config.database : defaultDatabase;
     return ok({
       schemaName: dbName,
-    })
+    });
   }
 
   async startTransaction() {
     const options: TransactionOptions = {
       usePhantomQuery: true,
-    }
+    };
 
-    const tag = '[js::startTransaction]'
-    debug(`${tag} options: %O`, options)
+    const tag = "[js::startTransaction]";
+    debug(`${tag} options: %O`, options);
 
-    const tx = await this.client.begin()
-    return ok(new TiDBCloudTransaction(tx, options))
+    const tx = await this.client.begin();
+    return ok(new TiDBCloudTransaction(tx, options));
   }
 }

--- a/src/tidbcloud.ts
+++ b/src/tidbcloud.ts
@@ -10,7 +10,7 @@ import type {
   Result,
   TransactionOptions,
 } from '@prisma/driver-adapter-utils'
-import {type TiDBCloudColumnType,fieldToColumnType} from './conversion'
+import {type TiDBCloudColumnType,fieldToColumnType,customerDecoder} from './conversion'
 
 const debug = Debug('prisma:driver-adapter:tidbcloud')
 
@@ -78,7 +78,7 @@ class TiDBCloudQueryable<ClientT extends TiDBCloud.Connection | TiDBCloud.Tx> im
     const { sql, args: values } = query
 
     try {
-      const result =  await this.client.execute(sql, values, {arrayMode: true, fullResult: true})
+      const result =  await this.client.execute(sql, values, {arrayMode: true, fullResult: true,decoders:customerDecoder})
       return result as TiDBCloud.FullResult
     } catch (e) {
       const error = e as Error


### PR DESCRIPTION
TiDB Cloud serverless driver supports Unit8Array as input in v0.1.0. But it has a break change in v0.1.0:
- It returns Uint8array rather than string for blob, binary and bit type

Prisma Accept string and array for these types. Thus, conversion error occurs.

This PR fix this.

## Test 
Test succeed locally

schema and codes:
```
generator client {
  provider        = "prisma-client-js"
  previewFeatures = ["driverAdapters"]
}

datasource db {
  provider     = "mysql"
  url          = env("DATABASE_URL")
}

model user {
  id    Int     @id @default(autoincrement())
  email String? @unique(map: "uniq_email") @db.VarChar(255)
  name  String? @db.VarChar(255)
  bytes Bytes?
}


import { connect } from '@tidbcloud/serverless';
import { PrismaTiDBCloud } from '@tidbcloud/prisma-adapter';
import { PrismaClient } from '@prisma/client';
import dotenv from 'dotenv';
import { fetch } from 'undici'

// setup
dotenv.config();
const connectionString = "xxx";
const connection = connect({ url: connectionString ,fetch});
const adapter = new PrismaTiDBCloud(connection);
const prisma = new PrismaClient({ adapter });


await prisma.user.deleteMany({})
// insert
const user = await prisma.user.create({
  data: {
    id: 1,
    email: 'test@prisma.io',
    name: 'test',
    bytes: Buffer.from('FSDF',"base64"),
  },
})
console.log(user)
```

result:
```
{
  id: 1,
  email: 'test@prisma.io',
  name: 'test',
  bytes: <Buffer 15 20 c5>
}

```

## Other

This PR format the whole codes