### PR TITLE
fix: additions for prisma 6.17 and engineType = "client" compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "license": "Apache-2.0",
   "sideEffects": false,
   "dependencies": {
-    "@prisma/driver-adapter-utils": "6.12.0"
+    "@prisma/driver-adapter-utils": "6.17.0"
   },
   "devDependencies": {
     "@tidbcloud/serverless": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@prisma/driver-adapter-utils':
-        specifier: 6.12.0
-        version: 6.12.0
+        specifier: 6.17.0
+        version: 6.17.0
     devDependencies:
       '@tidbcloud/serverless':
         specifier: ^0.1.0
@@ -223,8 +223,11 @@ packages:
   '@prisma/debug@6.12.0':
     resolution: {integrity: sha512-plbz6z72orcqr0eeio7zgUrZj5EudZUpAeWkFTA/DDdXEj28YHDXuiakvR6S7sD6tZi+jiwQEJAPeV6J6m/tEQ==}
 
-  '@prisma/driver-adapter-utils@6.12.0':
-    resolution: {integrity: sha512-uSUKB17Xs4pZB1UJZL6+PHV9Ab6vCWD20nXoimb5YG4vPqtBVdPKNYa35QbDgdUQbX321daUcgYTsLY/jxOG3w==}
+  '@prisma/debug@6.17.0':
+    resolution: {integrity: sha512-eE2CB32nr1hRqyLVnOAVY6c//iSJ/PN+Yfoa/2sEzLGpORaCg61d+nvdAkYSh+6Y2B8L4BVyzkRMANLD6nnC2g==}
+
+  '@prisma/driver-adapter-utils@6.17.0':
+    resolution: {integrity: sha512-JqK4STDoZVQnj7ac6+daN5w6l0Vns82tHdj8FVzMdCLMdWd2JgDzDS688gTMZt7rEDNJSb/z9U5XtIP0C08sWg==}
 
   '@prisma/engines-version@6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc':
     resolution: {integrity: sha512-70vhecxBJlRr06VfahDzk9ow4k1HIaSfVUT3X0/kZoHCMl9zbabut4gEXAyzJZxaCGi5igAA7SyyfBI//mmkbQ==}
@@ -823,9 +826,11 @@ snapshots:
 
   '@prisma/debug@6.12.0': {}
 
-  '@prisma/driver-adapter-utils@6.12.0':
+  '@prisma/debug@6.17.0': {}
+
+  '@prisma/driver-adapter-utils@6.17.0':
     dependencies:
-      '@prisma/debug': 6.12.0
+      '@prisma/debug': 6.17.0
 
   '@prisma/engines-version@6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc': {}
 

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -1,4 +1,8 @@
-import { ColumnTypeEnum, type ColumnType } from "@prisma/driver-adapter-utils";
+import {
+  ArgType,
+  ColumnTypeEnum,
+  type ColumnType,
+} from "@prisma/driver-adapter-utils";
 
 export type TiDBCloudColumnType =
   | "NULL"
@@ -116,4 +120,91 @@ function hexToUint8Array(hexString: string): Uint8Array {
     uint8Array[i / 2] = parseInt(hexString.substring(i, i + 2), 16);
   }
   return uint8Array;
+}
+
+export function mapArg<A>(
+  arg: A | Date,
+  argType: ArgType
+): null | BigInt | string | Uint8Array | A {
+  if (arg === null) {
+    return null;
+  }
+
+  if (typeof arg === "string" && argType.scalarType === "bigint") {
+    return BigInt(arg);
+  }
+
+  if (typeof arg === "string" && argType.scalarType === "datetime") {
+    arg = new Date(arg);
+  }
+
+  if (arg instanceof Date) {
+    switch (argType.dbType) {
+      case "TIME":
+      case "TIME2":
+        return formatTime(arg);
+      case "DATE":
+      case "NEWDATE":
+        return formatDate(arg);
+      default:
+        return formatDateTime(arg);
+    }
+  }
+
+  if (typeof arg === "string" && argType.scalarType === "bytes") {
+    return Buffer.from(arg, "base64");
+  }
+
+  if (Array.isArray(arg) && argType.scalarType === "bytes") {
+    return Buffer.from(arg);
+  }
+
+  if (ArrayBuffer.isView(arg)) {
+    return Buffer.from(arg.buffer, arg.byteOffset, arg.byteLength);
+  }
+
+  return arg;
+}
+
+function formatDateTime(date: Date): string {
+  const pad = (n: number, z = 2) => String(n).padStart(z, "0");
+  const ms = date.getUTCMilliseconds();
+  return (
+    date.getUTCFullYear() +
+    "-" +
+    pad(date.getUTCMonth() + 1) +
+    "-" +
+    pad(date.getUTCDate()) +
+    " " +
+    pad(date.getUTCHours()) +
+    ":" +
+    pad(date.getUTCMinutes()) +
+    ":" +
+    pad(date.getUTCSeconds()) +
+    (ms ? "." + String(ms).padStart(3, "0") : "")
+  );
+}
+
+function formatDate(date: Date): string {
+  const pad = (n: number, z = 2) => String(n).padStart(z, "0");
+  return (
+    date.getUTCFullYear() +
+    "-" +
+    pad(date.getUTCMonth() + 1) +
+    "-" +
+    pad(date.getUTCDate())
+  );
+}
+
+function formatTime(date: Date): string {
+  const pad = (n: number, z = 2) => String(n).padStart(z, "0");
+  const ms = date.getUTCMilliseconds();
+  return (
+    pad(date.getUTCHours()) +
+    ":" +
+    pad(date.getUTCMinutes()) +
+    ":" +
+    pad(date.getUTCSeconds()) +
+    (ms ? "." + String(ms).padStart(3, "0") : "")
+  );
 }

--- a/src/tidbcloud.ts
+++ b/src/tidbcloud.ts
@@ -15,6 +15,7 @@ import {
   type TiDBCloudColumnType,
   fieldToColumnType,
   customDecoder,
+  mapArg,
 } from "./conversion";
 import { name as packageName } from "../package.json";
 
@@ -89,11 +90,15 @@ class TiDBCloudQueryable<ClientT extends TiDBCloud.Connection | TiDBCloud.Tx>
     const { sql, args: values } = query;
 
     try {
-      const result = await this.client.execute(sql, values, {
-        arrayMode: true,
-        fullResult: true,
-        decoders: customDecoder,
-      });
+      const result = await this.client.execute(
+        sql,
+        values.map((val, i) => mapArg(val, query.argTypes[i])),
+        {
+          arrayMode: true,
+          fullResult: true,
+          decoders: customDecoder,
+        }
+      );
       return result as TiDBCloud.FullResult;
     } catch (e) {
       const error = e as Error;


### PR DESCRIPTION
Porting some additions from the prisma mariadb adapter. I haven't tested them carefully, but this makes it pass the prisma ecosystem tests.